### PR TITLE
Add marquee banner for opening dates on home page

### DIFF
--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -244,6 +244,11 @@ export function HeroSection() {
       </div>
       
       <div className="absolute inset-0 z-30 flex flex-col justify-between pt-16 md:pt-28 will-change-transform">
+        <div className="w-full overflow-hidden bg-black/50">
+          <div className="inline-block whitespace-nowrap animate-marquee px-4 py-2 text-japanese-gold font-kanteiryuu">
+            2025年10月1日プレオープン ・ 10月13日グランドオープン
+          </div>
+        </div>
         <div className="flex-1 flex items-center justify-center px-4">
           <div className="text-center w-full max-w-4xl mx-auto">
             <div className="mb-6 transition-opacity duration-300" style={{opacity: 1}}>

--- a/src/index.css
+++ b/src/index.css
@@ -103,3 +103,18 @@
   bottom: 4px;
   border: 1px solid #d1d5db;
 }
+
+@layer utilities {
+  @keyframes marquee {
+    0% {
+      transform: translateX(100%);
+    }
+    100% {
+      transform: translateX(-100%);
+    }
+  }
+
+  .animate-marquee {
+    animation: marquee 15s linear infinite;
+  }
+}


### PR DESCRIPTION
## Summary
- display pre-open and grand opening dates in a scrolling banner on the home hero section
- add marquee animation utility to global styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4453873ac832bb56f207b7790db81