### PR TITLE
Improve marquee and menu button styling

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -49,8 +49,16 @@ export function Layout({ children }: { children: React.ReactNode }) {
     <div className="min-h-screen bg-stone-50">
       <nav className="fixed w-full z-50">
         <div className="w-full overflow-hidden bg-black/50">
-          <div className="inline-block whitespace-nowrap animate-marquee px-4 py-2 text-japanese-gold font-kanteiryuu">
-            2025年10月1日プレオープン ・ 10月13日グランドオープン
+          <div className="animate-marquee">
+            <span className="whitespace-nowrap px-4 py-2 text-japanese-gold font-kanteiryuu">
+              2025年10月1日プレオープン ・ 10月13日グランドオープン
+            </span>
+            <span
+              className="whitespace-nowrap px-4 py-2 text-japanese-gold font-kanteiryuu"
+              aria-hidden="true"
+            >
+              2025年10月1日プレオープン ・ 10月13日グランドオープン
+            </span>
           </div>
         </div>
         <div className="container mx-auto px-4">

--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import { Utensils, Clock, MapPin, Phone } from 'lucide-react';
+import { Utensils, Beer, Clock, MapPin, Phone } from 'lucide-react';
 import { motion } from 'framer-motion';
 
 // Optimize image loading with smaller images and proper dimensions
@@ -259,18 +259,18 @@ export function HeroSection() {
             </div>
             
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link 
-                to="/lunch" 
-                className="bg-japanese-red hover:bg-red-800 text-white px-8 py-3 rounded-md transition-colors duration-300 flex items-center justify-center gap-2 shadow-lg hover:shadow-xl transform hover:scale-105 font-kanteiryuu"
+              <Link
+                to="/lunch"
+                className="bg-[#722F37] hover:bg-[#5B2430] text-white px-8 py-3 rounded-md transition-colors duration-300 flex items-center justify-center gap-2 shadow-lg hover:shadow-xl transform hover:scale-105 font-kanteiryuu"
               >
                 <Utensils className="w-5 h-5" />
                 ランチメニュー
               </Link>
-              <Link 
-                to="/izakaya" 
-                className="bg-japanese-indigo hover:bg-blue-900 text-white px-8 py-3 rounded-md transition-colors duration-300 flex items-center justify-center gap-2 shadow-lg hover:shadow-xl transform hover:scale-105 font-kanteiryuu"
+              <Link
+                to="/izakaya"
+                className="bg-[#0A1A44] hover:bg-[#050E22] text-white px-8 py-3 rounded-md transition-colors duration-300 flex items-center justify-center gap-2 shadow-lg hover:shadow-xl transform hover:scale-105 font-kanteiryuu"
               >
-                <Utensils className="w-5 h-5" />
+                <Beer className="w-5 h-5" />
                 居酒屋メニュー
               </Link>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -106,15 +106,17 @@
 
 @layer utilities {
   @keyframes marquee {
-    from {
-      transform: translateX(100%);
+    0% {
+      transform: translateX(0);
     }
-    to {
-      transform: translateX(-100%);
+    100% {
+      transform: translateX(-50%);
     }
   }
 
   .animate-marquee {
+    display: flex;
+    width: max-content;
     animation: marquee 15s linear infinite;
   }
 }


### PR DESCRIPTION
## Summary
- make top banner text scroll continuously without gaps
- switch izakaya menu button to beer icon and refine colors of menu buttons
- tune marquee animation styles for seamless loop

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b44fc1f874832b82fba5820b940ec9