### PR TITLE
Preload Yuji Syuku font with swap fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <!-- Preconnect hints for critical third-party resources -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" href="https://fonts.gstatic.com/s/YujiSyuku.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Yuji+Syuku:wght@400&display=swap">
     <link rel="preconnect" href="https://i.ibb.co" crossorigin>
     <link rel="preconnect" href="https://www.googletagmanager.com">
     <link rel="dns-prefetch" href="//www.instagram.com">
@@ -60,15 +62,6 @@
       /* logo preload div を廃止（オフスクリーン画像の早期読み込みを防止） */
     </style>
 
-    <!-- Google Fonts はユーザー操作後、または4秒経過後に読み込み（LCP前のネットワーク競合を避ける） -->
-    <script>
-      (function(){
-        var loaded=false;function loadFont(){if(loaded) return;loaded=true;var l=document.createElement('link');l.rel='stylesheet';l.href='https://fonts.googleapis.com/css2?family=Yuji+Syuku:wght@400&display=swap';document.head.appendChild(l);} 
-        ['click','keydown','touchstart'].forEach(function(e){window.addEventListener(e,loadFont,{once:true,passive:true});});
-        // フォールバックは4秒後（回線が速い環境でもLCP以降になりやすい）
-        window.addEventListener('load',function(){setTimeout(loadFont,4000);});
-      })();
-    </script>
     
     <meta property="og:title" content="十割蕎麦・焼鳥酒場 『一期一美』 - ichibi - | 君津の手打十割そば・厳選した国産鶏のやきとり">
     <meta property="og:description" content="【2025年10月13日グランドオープン・10月1日プレオープン】千葉県君津市内蓑輪にある石臼挽き手打十割そばと厳選した国産鶏のやきとりを提供するお店。">


### PR DESCRIPTION
## Summary
- preconnect and preload Yuji Syuku font
- load Google Fonts stylesheet in head and remove delayed loader
- keep serif fallbacks for immediate text rendering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b45a6edc34832b92b7d7940eb54f8a