### PR TITLE
LCP改善: フォントとプリロード最適化\n\n- 不要な画像プリロードを削除し帯域を最適化\n- ヒーロー画像URLを統一（クエリ削除）…

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,11 +16,7 @@
     
     <link rel="icon" href="/image/ichigo_ichibi_logo.svg" type="image/svg+xml">
     
-    <!-- Preload critical images -->
-    <link rel="preload" href="/image/ichigo_ichibi_logo.svg" as="image" type="image/svg+xml" fetchpriority="high">
-    <link rel="preload" href="/image/soba.webp" as="image" type="image/webp">
-    <link rel="preload" href="/image/yakitori.webp" as="image" type="image/webp">
-    <link rel="preload" href="/image/nihonnshu.webp" as="image" type="image/webp">
+    <!-- Avoid preloading non‑LCP images to reduce wasted bandwidth -->
     
     <style>
       :root {
@@ -60,8 +56,9 @@
     <!-- Preload local Yuji Syuku font (WOFF2) -->
     <link rel="preload" as="font" href="/fonts/yuji-syuku/yuji-syuku.woff2" type="font/woff2" crossorigin>
 
-    <!-- Self-hosted Yuji Syuku font (if present) -->
-    <link id="local-yuji-syuku" rel="stylesheet" href="/fonts/yuji-syuku/yuji-syuku.css">
+    <!-- Self-hosted Yuji Syuku font: load non-blocking -->
+    <link id="local-yuji-syuku" rel="preload" as="style" href="/fonts/yuji-syuku/yuji-syuku.css" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="/fonts/yuji-syuku/yuji-syuku.css"></noscript>
 
     <!-- オフライン前提のため、Google Fonts フォールバックは削除 -->
     

--- a/public/fonts/yuji-syuku/yuji-syuku.css
+++ b/public/fonts/yuji-syuku/yuji-syuku.css
@@ -6,7 +6,8 @@
   font-family: 'Yuji Syuku';
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  /* Avoid delaying LCP due to webfont; allow fallback if slow */
+  font-display: optional;
   src:
     url('/fonts/yuji-syuku/yuji-syuku.woff2') format('woff2'),
     url('/fonts/yuji-syuku/yuji-syuku.ttf') format('truetype');

--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -4,6 +4,8 @@ import { Utensils, Beer, Clock, MapPin, Phone } from 'lucide-react';
 import { motion } from 'framer-motion';
 
 // Optimize image loading with smaller images and proper dimensions
+// Keep URLs identical between preloaders and consumers (no query string)
+// to prevent "preloaded but not used" warnings and improve LCP.
 const SLIDER_IMAGES = [
   {
     url: "/image/soba.webp",
@@ -19,10 +21,11 @@ const SLIDER_IMAGES = [
   }
 ].map(img => ({
   ...img,
-  url: `${img.url}?auto=format&fit=crop&w=1920&h=1080&q=75`,
-  smallUrl: `${img.url}?auto=format&fit=crop&w=640&h=360&q=60`,
-  mediumUrl: `${img.url}?auto=format&fit=crop&w=1280&h=720&q=70`,
-  placeholder: `${img.url}?auto=format&fit=crop&w=20&h=10&q=10&blur=10`
+  // For now we serve the same asset at all sizes. When a CDN
+  // is introduced, these can point to real variants.
+  smallUrl: img.url,
+  mediumUrl: img.url,
+  placeholder: img.url
 }));
 
 export function HeroSection() {


### PR DESCRIPTION
…して preloaded but not used を解消\n- 自前Yujiフォントを非ブロッキング読み込み（preload as=style + onload）へ\n- font-display: optional でFOIT回避しLCP要素の表示を優先\n\nビルド確認済み（vite）。