### PR TITLE
Remove Crawl-delay directive from robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,5 +4,3 @@ Allow: /
 # Sitemap
 Sitemap: https://ichibi.netlify.app/sitemap.xml
 
-# Crawl-delay
-Crawl-delay: 1

--- a/src/components/home/brand-story.tsx
+++ b/src/components/home/brand-story.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 
 export function BrandStory() {


### PR DESCRIPTION
## Summary
- remove unsupported `Crawl-delay` from robots.txt
- tidy BrandStory component by dropping unused Link import

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0018a2008832b981f19fb0b126f00