### PR TITLE
Load Yuji Syuku font with standard link

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#1B315E">
+    <link rel="preload" href="/fonts/yuji-syuku/yuji-syuku.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="stylesheet" href="/fonts/yuji-syuku/yuji-syuku.css">
     
     <!-- Preconnect hints for critical third-party resources -->
     <link rel="preconnect" href="https://www.googletagmanager.com">
@@ -54,14 +56,6 @@
       /* logo preload div を廃止（オフスクリーン画像の早期読み込みを防止） */
     </style>
 
-    <!-- Webフォントは初期表示では読み込まない（JSで遅延ロード） -->
-    <noscript>
-      <!-- JS無効時のみ通常読み込み -->
-      <link rel="stylesheet" href="/fonts/yuji-syuku/yuji-syuku.css">
-    </noscript>
-
-    <!-- オフライン前提のため、Google Fonts フォールバックは削除 -->
-    
     <meta property="og:title" content="十割蕎麦・焼鳥酒場 『一期一美』 - ichibi - | 君津の手打十割そば・厳選した国産鶏のやきとり">
     <meta property="og:description" content="【2025年10月13日グランドオープン・10月1日プレオープン】千葉県君津市内蓑輪にある石臼挽き手打十割そばと厳選した国産鶏のやきとりを提供するお店。">
     <meta property="og:image" content="/image/soba.webp">
@@ -106,24 +100,6 @@
         });
       });
 
-      // Lazy‑load self‑hosted font CSS after initial render
-      function loadFonts() {
-        if (document.getElementById('local-yuji-syuku')) return;
-        var link = document.createElement('link');
-        link.id = 'local-yuji-syuku';
-        link.rel = 'stylesheet';
-        link.href = '/fonts/yuji-syuku/yuji-syuku.css';
-        link.media = 'print';
-        link.onload = function() { this.media = 'all'; };
-        document.head.appendChild(link);
-      }
-
-      // 余裕のあるタイミングで読み込み
-      if ('requestIdleCallback' in window) {
-        (window).requestIdleCallback(loadFonts, { timeout: 2500 });
-      } else {
-        window.addEventListener('load', function() { setTimeout(loadFonts, 1500); });
-      }
     </script>
     
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- load the Yuji Syuku font stylesheet directly in the initial HTML response
- preload the Yuji Syuku font file to trigger earlier download by the browser
- remove the JavaScript lazy-loading logic and related noscript fallback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbeb54b488832ba68fa8dc25bdb07f