### PR TITLE
Adjust hero title and header brand text

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -103,7 +103,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         </div>
         <div className="container mx-auto px-4">
           <div className="relative flex items-center justify-between py-4 md:py-6">
-            <Link to="/" className="flex items-center">
+            <Link to="/" className="flex items-center gap-3 md:gap-4">
               <img
                 src={logo}
                 alt="一期一美"
@@ -118,6 +118,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
                   }
                 }}
               />
+              <span className="text-white font-kanteiryuu text-base leading-tight md:text-xl lg:text-2xl">
+                十割蕎麦・焼鳥酒場『一期一美』 - ichibi -
+              </span>
             </Link>
             <div className="hidden md:flex space-x-4">
               <Link

--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -154,11 +154,15 @@ export function HeroSection() {
         <div className="flex-1 flex items-center justify-center px-4">
           <div className="text-center w-full max-w-4xl mx-auto">
             <div className="mb-6 transition-opacity duration-300" style={{opacity: 1}}>
-              <h1 className="text-4xl md:text-6xl lg:text-7xl font-kanteiryuu text-white mb-4">
-                <div className="text-2xl md:text-3xl lg:text-4xl mb-2 font-kanteiryuu">十割蕎麦・焼鳥酒場</div>
-                <div className="text-4xl md:text-6xl lg:text-7xl font-kanteiryuu">『一期一美』</div>
-                <div className="text-xl md:text-2xl lg:text-3xl mt-2 font-kanteiryuu">- ichibi -</div>
+              <h1 className="text-3xl md:text-5xl lg:text-6xl font-kanteiryuu text-white mb-3 leading-snug">
+                十割蕎麦・焼鳥酒場『一期一美』
+                <span className="block text-2xl md:text-3xl lg:text-4xl mt-2 font-kanteiryuu">
+                  | 千葉県君津市の手打十割蕎麦・焼鳥・定食
+                </span>
               </h1>
+              <div className="text-xl md:text-2xl lg:text-3xl font-kanteiryuu text-white mb-3">
+                - ichibi -
+              </div>
               <p className="text-lg md:text-xl text-japanese-gold font-medium font-kanteiryuu">
                 千葉県君津市内蓑輪の手打十割蕎麦をメインとしたランチと焼き鳥居酒屋の店
               </p>


### PR DESCRIPTION
## Summary
- align the hero headline with the requested full title including the location descriptor
- show the restaurant's full official name next to the logo in the header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d470c98600832ba2000816a49f2f1e