### PR TITLE
Fix tax labels on menu prices

### DIFF
--- a/src/components/menu/menu-item.tsx
+++ b/src/components/menu/menu-item.tsx
@@ -109,7 +109,7 @@ export function MenuItem({ name, price, allergens = [], description }: MenuItemP
         </div>
         <div className="text-right">
           <p className="text-japanese-red font-semibold">
-            {formatPrice(normalizedPrice)} (税抜{formatPrice(taxExcludedPrice)})
+            税抜{formatPrice(taxExcludedPrice)} (税込{formatPrice(taxIncludedPrice)})
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update menu item price label to show tax-excluded amount followed by the tax-included amount for clarity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db4e0cf068832bb3f1e66d1b518a12