### PR TITLE
Ensure kids drink pricing display matches rest of menu

### DIFF
--- a/src/components/menu/menu-item.tsx
+++ b/src/components/menu/menu-item.tsx
@@ -36,11 +36,18 @@ export interface MenuItemProps {
   price: string | number;
   allergens?: Allergen[];
   description?: string;
+  priceLabel?: string;
 }
 
 const TAX_RATE = 0.1;
 
-export function MenuItem({ name, price, allergens = [], description }: MenuItemProps) {
+export function MenuItem({
+  name,
+  price,
+  allergens = [],
+  description,
+  priceLabel,
+}: MenuItemProps) {
   const priceNumber =
     typeof price === 'number' ? price : parseInt(price.toString().replace(/[^\d]/g, ''), 10);
   const normalizedPrice = Number.isFinite(priceNumber) ? priceNumber : 0;
@@ -109,7 +116,7 @@ export function MenuItem({ name, price, allergens = [], description }: MenuItemP
         </div>
         <div className="text-right">
           <p className="text-japanese-red font-semibold">
-            税抜{formatPrice(taxExcludedPrice)} (税込{formatPrice(taxIncludedPrice)})
+            {priceLabel ?? `税抜${formatPrice(taxExcludedPrice)} (税込${formatPrice(taxIncludedPrice)})`}
           </p>
         </div>
       </div>

--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -139,14 +139,10 @@ const riceBowlItems: BasicMenuItem[] = [
   },
 ];
 
-const kidsMenuItems: BasicMenuItem[] = [
+const kidsFoodItems: BasicMenuItem[] = [
   {
     name: 'キッズプレート',
     price: 300,
-  },
-  {
-    name: 'キッズドリンク',
-    price: 100,
   },
 ];
 
@@ -324,6 +320,12 @@ const softDrinkItems: BasicMenuItem[] = [
   { name: '緑茶', price: 400 },
   { name: 'ウーロン茶', price: 400 },
 ];
+
+const kidsDrinkItems: BasicMenuItem[] = softDrinkItems.map((item) => ({
+  name: item.name,
+  price: 100,
+  priceLabel: '税込100円',
+}));
 
 const izakayaYakitoriItems = [
   { name: 'もも', price: 170, allergens: ['鶏肉'] },
@@ -545,9 +547,17 @@ function LunchMenu() {
             <div>
               <h3 className="text-xl font-kanteiryuu mb-6 pb-2 border-b-2 border-japanese-red">キッズメニュー</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                {kidsMenuItems.map((item) => (
+                {kidsFoodItems.map((item) => (
                   <MenuItem key={item.name} {...item} />
                 ))}
+              </div>
+              <div className="mt-8">
+                <h4 className="text-lg font-kanteiryuu mb-4 text-gray-700">キッズドリンク</h4>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                  {kidsDrinkItems.map((item) => (
+                    <MenuItem key={`kids-drink-${item.name}`} {...item} />
+                  ))}
+                </div>
               </div>
             </div>
 
@@ -672,9 +682,17 @@ function IzakayaMenu() {
             <div>
               <h3 className="text-xl font-kanteiryuu mb-6 pb-2 border-b-2 border-japanese-red">キッズメニュー</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                {kidsMenuItems.map((item) => (
+                {kidsFoodItems.map((item) => (
                   <MenuItem key={item.name} {...item} />
                 ))}
+              </div>
+              <div className="mt-8">
+                <h4 className="text-lg font-kanteiryuu mb-4 text-gray-700">キッズドリンク</h4>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                  {kidsDrinkItems.map((item) => (
+                    <MenuItem key={`kids-drink-${item.name}`} {...item} />
+                  ))}
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- derive the kids drink menu from the soft drink lineup so each option is available for children
- show the dedicated kids drink section in both menu views with tax-included 100 yen pricing
- allow menu items to override their price label so kids drinks render a consistent 税込100円 display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db4f49bf94832bacc109f4a4f85870